### PR TITLE
Remove spinner from Outside of Plan input

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,14 @@
 body { padding: 2rem; }
 .select-container { margin-top: 1rem; }
 .output { margin-top: 2rem; }
+.no-spinner::-webkit-inner-spin-button,
+.no-spinner::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.no-spinner {
+  -moz-appearance: textfield;
+}
 </style>
 </head>
 <body>
@@ -40,7 +48,7 @@ body { padding: 2rem; }
     <div class="field">
       <label class="label" for="additional">Outside of Plan ($)</label>
       <div class="control">
-        <input class="input" type="number" id="additional" min="0" step="0.01" value="0">
+        <input class="input no-spinner" type="number" id="additional" min="0" step="0.01" value="0">
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- hide number input spinner
- apply to Outside of Plan field so it only accepts typed values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865a1391fe0832596001ad670ad6b44